### PR TITLE
fix(FAM-709): Fix batch files

### DIFF
--- a/bin/windows/connect-mirror-maker.bat
+++ b/bin/windows/connect-mirror-maker.bat
@@ -26,9 +26,8 @@ set BASE_DIR=%CD%
 popd
 
 rem Log4j settings
-IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
-    rem SET KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:"%BASE_DIR%/../config/connect-log4j.properties"
-    SET "KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%BASE_DIR%/config/log4j.properties"
+IF NOT DEFINED KAFKA_LOG4J_OPTS (
+	set "KAFKA_LOG4J_OPTS=-Dlog4j2.configurationFile=%BASE_DIR%/config/connect-log4j2.yaml"
 )
 
 "%~dp0kafka-run-class.bat" org.apache.kafka.connect.mirror.MirrorMaker %*

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -112,7 +112,7 @@ IF NOT DEFINED LOG_DIR (
 
 rem Log4j settings
 IF NOT DEFINED KAFKA_LOG4J_OPTS (
-	set "KAFKA_LOG4J_OPTS=-Dlog4j2.configurationFile=file:%BASE_DIR%/config/tools-log4j2.yaml"
+	set "KAFKA_LOG4J_OPTS=-Dlog4j2.configurationFile=%BASE_DIR%/config/tools-log4j2.yaml"
 ) ELSE (
     rem Check if Log4j 1.x configuration options are present in KAFKA_LOG4J_OPTS
     echo %KAFKA_LOG4J_OPTS% | findstr /r /c:"log4j\.[^ ]*(\.properties|\.xml)$" >nul


### PR DESCRIPTION
Fix the windows batch files to prevent errors
- kafka-run-class: log4j2 configuration parameter was wrong
- connect-mirror-maker: Fix windows path expansion and use connect
log4j2 configuration
