### PR TITLE
fix(FAM-709): Fix variable reference in deprecation message

### DIFF
--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -121,7 +121,7 @@ IF NOT DEFINED KAFKA_LOG4J_OPTS (
         set LOG4J_COMPATIBILITY=true
         echo DEPRECATED: A Log4j 1.x configuration file has been detected, which is no longer recommended. >&2
         echo To use a Log4j 2.x configuration, please see https://logging.apache.org/log4j/2.x/migrate-from-log4j1.html#Log4j2ConfigurationFormat for details about Log4j configuration file migration. >&2
-        echo You can also use the %BASE_DIR%/config/tool-log4j2.yaml file as a starting point. Make sure to remove the Log4j 1.x configuration after completing the migration. >&2
+        echo You can also use the !BASE_DIR!/config/tool-log4j2.yaml file as a starting point. Make sure to remove the Log4j 1.x configuration after completing the migration. >&2
     )
   rem create logs directory
   IF not exist "%LOG_DIR%" (


### PR DESCRIPTION
While testing with the real installation path, I found out there was an error when running commands, preventing the Kafka service to start properly.
